### PR TITLE
fix: exception on initial connect

### DIFF
--- a/src/re_frisk_remote/core.cljs
+++ b/src/re_frisk_remote/core.cljs
@@ -21,6 +21,7 @@
           "/chsk"
           {:type   :auto
            :host   host
+           :protocol :http
            :packer (sente-transit/get-transit-packer
                      :json
                      {:handlerForForeign (fn [x h] (transit/write-handler (fn [o] "ForeignType")


### PR DESCRIPTION
## got exception on initial connect
```
cljs$core$ExceptionInfo
message: "Invariant violation in taoensso.sente:? [pred-form, val]:↵ [([:el #{"https:" "http:"}] protocol), file:]"
name: "Error"
```

**trace:**
```
taoensso$truss$impl$default_error_fn	@	impl.cljs:62
taoensso$truss$impl$_invar_violation_BANG_	@	impl.cljs:158
(anonymous)	@	sente.cljc:1379
taoensso$sente$get_chsk_url	@	sente.cljc:1379
(anonymous)	@	sente.cljc:1440
taoensso.sente.make_channel_socket_client_BANG_.cljs$core$IFn$_invoke$arity$variadic	@	sente.cljc:1441
taoensso$sente$make_channel_socket_client_BANG_	@	sente.cljc:1386
re_frisk_remote$core$start_socket	@	core.cljs:20
re_frisk_remote.core.enable_re_frisk_remote_BANG_.cljs$core$IFn$_invoke$arity$variadic	@	core.cljs:41
re_frisk_remote$core$enable_re_frisk_remote_BANG_	@	core.cljs:39
```