### PR TITLE
Compute event time diff before db diff

### DIFF
--- a/src/re_frisk_remote/core.cljs
+++ b/src/re_frisk_remote/core.cljs
@@ -29,10 +29,11 @@
   (@chsk-send!* [:refrisk/pre-events value]))
 
 (defn post-event-callback [value]
-  (@chsk-send!* [:refrisk/events (conj {:app-db-diff (app-db-diff)}
-                                       (if @evnt-time*
-                                         {:time (- (js/Date.now) @evnt-time*)}
-                                         {:event value}))]))
+  (let [event-data (if @evnt-time*
+                     {:time (- (js/Date.now) @evnt-time*)}
+                     {:event value})]
+    (@chsk-send!* [:refrisk/events (conj {:app-db-diff (app-db-diff)}
+                                         event-data)])))
 
 (defn re-frame-sub [& rest]
   ;; TODO send diff


### PR DESCRIPTION
Computing `app-db-diff` is expensive procedure where time to compute grows linearly with size of the db. 
It dominates the event-time displayed (of most events doing any change in db) even when re-frame `app-db` is quite small, when it's little bit bigger, the time to compute the diff totally dwarfs the actual event execution time, so it's essential that the diffing operation is excluded from the event-time to not skew the results.
This PR achieves that by simply moving event-time computation higher up, ensuring that it's evaluated before diffing.