### PR TITLE
Integrate re-frame-10x

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Or select a different host and port by supplying the host and port number:
 (enable-re-frisk-remote! {:host "192.168.1.1:8095"})
 ```
 
+You could also provide options `:enable-re-frisk? false` or `:enable-re-frame-10x? true` to enable/disable sending traces for respective component while re-frame-10x is disabled by default.
+
+
 Run re-frisk remote server using leiningen re-frisk [plugin](https://github.com/flexsurfer/lein-re-frisk)
 
 `$ lein re-frisk`

--- a/project.clj
+++ b/project.clj
@@ -9,5 +9,4 @@
                  [com.taoensso/timbre "4.7.4"]
                  [com.taoensso/sente "1.11.0"]
                  [com.cognitect/transit-cljs "0.8.239"]
-                 [status-im/re-frame-10x "0.3.0-RN"]
                  [re-frisk "0.5.4"]])

--- a/project.clj
+++ b/project.clj
@@ -9,4 +9,5 @@
                  [com.taoensso/timbre "4.7.4"]
                  [com.taoensso/sente "1.11.0"]
                  [com.cognitect/transit-cljs "0.8.239"]
+                 [status-im/re-frame-10x "0.3.0-RN"]
                  [re-frisk "0.5.4"]])

--- a/src/re_frisk_remote/core.cljs
+++ b/src/re_frisk_remote/core.cljs
@@ -6,7 +6,6 @@
             [re-frame.core :refer [subscribe] :as re-frame]
             [re-frisk.diff :as diff]
             [re-frisk.delta :as delta]
-            [day8.re-frame-10x :as rft]
             [taoensso.sente.packers.transit :as sente-transit]
             [cognitect.transit :as transit]
             [taoensso.timbre :as timbre])


### PR DESCRIPTION
Fixes #7

First part of https://github.com/Day8/re-frame-10x integration.

It's going to send re-frame traces to re-frisk-sidecar server to be able to render those traces in re-frisk-sidecar client.